### PR TITLE
Handle case where there's 2 leading spaces

### DIFF
--- a/test/parseLink.js
+++ b/test/parseLink.js
@@ -8,6 +8,7 @@ describe('DDG.parse_link', function() {
         ['foo <a href="http://foobar.com">bars</a>', 'text', 'bars'],
         ['<a href="http://foobar.com">bars</a>foo<a href="http://foobar.com">bars</a>', 'rest', 'foobars'],
         ['<a href="http://foobar.com">blah</a> - something', 'rest', 'something'],
+        ['<a href="http://foobar.com">blah</a>  - something', 'rest', 'something'],
         ['<a href="http://foobar.com">blah</a>, something', 'rest', 'something'],
         ['"<a href="http://foobar.com">blah</a>" something', 'rest', 'something']
     ];

--- a/util.js
+++ b/util.js
@@ -443,7 +443,7 @@
             result = $tmp_p.text();
             if (result) {
                 // trim + strip any leading punctuation:
-                result = result.replace(/^( +)?(\-|\:|\;|,|"\s?") ?/,'');
+                result = result.replace(/^(\-|\:|\;|,|"|'|\s)+/,'');
             }
         } else if (wanted === "url") {
             result = $firstLink[0].href;

--- a/util.js
+++ b/util.js
@@ -443,7 +443,7 @@
             result = $tmp_p.text();
             if (result) {
                 // trim + strip any leading punctuation:
-                result = result.replace(/^ ?(\-|\:|\;|,|"\s?") ?/,'');
+                result = result.replace(/^( +)?(\-|\:|\;|,|"\s?") ?/,'');
             }
         } else if (wanted === "url") {
             result = $firstLink[0].href;


### PR DESCRIPTION
![screen shot 2015-09-30 at 10 06 12 am](https://cloud.githubusercontent.com/assets/126358/10195352/3441fc70-675b-11e5-89da-1325ee1da953.png)

I thought I fixed this, but it turns out there's 2!!! leading spaces. Added a test and adjusted the regex to fix it.

@andrey-p 
cc @mrshu @b1ake 
