### PR TITLE
add unescape function

### DIFF
--- a/test/unescape.js
+++ b/test/unescape.js
@@ -1,0 +1,23 @@
+describe('DDG.unescape()', function() {
+
+    var tests = [
+        // no matched entities:
+        ['this is something &else', 'this is something &else'],
+
+        // only one entity
+        ['2 &gt; 1', '2 > 1'],
+
+        // one entity after the other
+        ['this is a diamond! &lt;&gt;','this is a diamond! <>'],
+        
+        // one entity and one lonely &
+        ['true &amp;& false', 'true && false']
+    ];
+
+    tests.forEach(function(test) {
+        it('should unescape HTML entities correctly', function() {
+            expect(DDG.unescape(test[0])).toEqual(test[1]);
+        });
+    });
+
+});

--- a/util.js
+++ b/util.js
@@ -640,4 +640,20 @@
         return url && url.replace(/^https/, "http");
     };
 
+    /**
+     * Unescapes HTML entities so the text in which they appear can be displayed as text of DOM elements
+     * 
+     * This implementation is as suggested by the MDN:
+     * https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+     *
+     * @param {String} html foto escape entities
+     * 
+     * @return {String}
+     */
+    DDG.unescape = function(text) {
+        var doc = document.implementation.createHTMLDocument("example");
+        doc.documentElement.innerHTML = text;
+        return doc.body.textContent;
+    };
+
 })(this);


### PR DESCRIPTION
add a version of unescape copied from underscore, which takes an string with HTML entities in it for unescaping

This would help remove things like:
- https://github.com/duckduckgo/zeroclickinfo-spice/pull/2586
- https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/share/spice/couprex/couprex.js#L8
- https://github.com/duckduckgo/zeroclickinfo-spice/blob/41561b186c29121086b320db72c3a7d1afcb7b5a/share/spice/reddit_sub_search/reddit_sub_search.js#L46
