### PR TITLE
Add DDG.addSearchParam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 bower_components
+.grunt
+_SpecRunner.html

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-utils",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Util functions used by DuckDuckGo",
   "main": "util.js",
   "license": "Apache2",

--- a/test/addSearchParam.js
+++ b/test/addSearchParam.js
@@ -26,10 +26,10 @@ describe('DDG.addSearchParam()', function() {
     });
 
     it('should work with various protocols', function() {
-        expect(DDG.addSearchParam('wss://duckduckgo.com?atb=v100-1#main', 'this', 'works'))
+        expect(DDG.addSearchParam('wss://duckduckgo.com/?atb=v100-1#main', 'this', 'works'))
             .toEqual('wss://duckduckgo.com/?atb=v100-1&this=works#main');
 
-        expect(DDG.addSearchParam('ftp://duckduckgo.com?atb=v100-1#main', 'this', 'works'))
+        expect(DDG.addSearchParam('ftp://duckduckgo.com/?atb=v100-1#main', 'this', 'works'))
             .toEqual('ftp://duckduckgo.com/?atb=v100-1&this=works#main');
     });
 

--- a/test/addSearchParam.js
+++ b/test/addSearchParam.js
@@ -1,0 +1,40 @@
+describe('DDG.addSearchParam()', function() {
+
+    it('should add ?q=test to the URL', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com', 'q', 'test'))
+            .toEqual('https://duckduckgo.com/?q=test');
+    });
+
+    it('should ignore existing ?', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com?', 'q', 'test'))
+            .toEqual('https://duckduckgo.com/?q=test');
+    });
+
+    it('shouldn\'t change existing params', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com?atb=v100-1', 'q', 'test'))
+            .toEqual('https://duckduckgo.com/?atb=v100-1&q=test');
+    });
+
+    it('shouldn\'t change the hash', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com?atb=v100-1#main', 'q', 'test'))
+            .toEqual('https://duckduckgo.com/?atb=v100-1&q=test#main');
+    });
+
+    it('should encode the key and the value', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com?atb=v100-1#main', 'oh?no', 'this&is#wrong'))
+            .toEqual('https://duckduckgo.com/?atb=v100-1&oh%3Fno=this%26is%23wrong#main');
+    });
+
+    it('should work with various protocols', function() {
+        expect(DDG.addSearchParam('wss://duckduckgo.com?atb=v100-1#main', 'this', 'works'))
+            .toEqual('wss://duckduckgo.com/?atb=v100-1&this=works#main');
+
+        expect(DDG.addSearchParam('ftp://duckduckgo.com?atb=v100-1#main', 'this', 'works'))
+            .toEqual('ftp://duckduckgo.com/?atb=v100-1&this=works#main');
+    });
+
+    it('should only append key if no value is provided', function() {
+        expect(DDG.addSearchParam('https://duckduckgo.com', 'key'))
+            .toEqual('https://duckduckgo.com/?key');
+    });
+});

--- a/util.js
+++ b/util.js
@@ -648,6 +648,36 @@
         return url && url.replace(/^https/, "http");
     };
 
+    // IE11 does not support URL API, we have to use the second best thing 
+    var urlParser = document.createElement('a');
+
+    /**
+     * Adds search parameter to given url e.g., adding key "q" with value "test" to "https://duckduckgo.com" returns "http://duckduckgo.com?q=test".
+     *
+     * @param {string} url
+     * @param {string} key
+     * @param {string} value **[optional]** 
+     * 
+     * @return {string}
+     */
+    DDG.addSearchParam = function(url, key, value) {
+        urlParser.href = url;
+    
+        var encodedData = encodeURIComponent(key);
+
+        if (value) {
+            encodedData += '=' + encodeURIComponent(value);
+        }
+    
+        if (urlParser.search.length > 0 && urlParser.search !== '?') {
+            urlParser.search += '&' + encodedData;
+        } else {
+            urlParser.search = '?' + encodedData;
+        }
+    
+        return urlParser.href;
+    };
+
     /**
      * Unescapes HTML entities so the text in which they appear can be displayed as text of DOM elements
      * 


### PR DESCRIPTION
We need a way to safely manipulate search params of URLs. `DDG.addSearchParam` provides that functionality. 