### PR TITLE
Fix 1.5B being outputted as 15B

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "duckduckgo-utils",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Util functions used by DuckDuckGo",
   "main": "util.js",
   "license": "Apache2",

--- a/util.js
+++ b/util.js
@@ -28,7 +28,7 @@
         if (num < 1000000) { return Math.round(num / 1000) + 'K'; }
         if (num < 10000000) { return (Math.round(num / 100000) / 10) + 'M'; }
         if (num < 1000000000) { return Math.round(num / 1000000) + 'M'; }
-        if (num < 10000000000) { return Math.round(num / 100000000) + 'B'; }
+        if (num < 10000000000) { return (Math.round(num / 100000000) / 10) + 'B'; }
         return Math.round(num / 1000000000) + 'B';
     };
 


### PR DESCRIPTION
There was a bug where 1.5B (1 500 000 000) was outputted as 15B by `abbrevNumbers`. This PR fixes this bug.