### PR TITLE
Updated badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # duckduckgo-utils
 JS utility methods used by DuckDuckGo
 
-[![Build Status](https://travis-ci.org/duckduckgo/duckduckgo-utils.svg)](https://travis-ci.org/duckduckgo/duckduckgo-utils)
+[![Build Status](https://api.travis-ci.org/duckduckgo/duckduckgo-utils.svg?branch=master)](https://travis-ci.org/duckduckgo/duckduckgo-utils)


### PR DESCRIPTION
The badge was reporting a build error of some sort, likely from another branch or someone's PR. The badge now correctly points to the master branch :)